### PR TITLE
修复一个可能的资源注入问题

### DIFF
--- a/app/src/main/java/me/teble/xposed/autodaily/hook/proxy/activity/ResInjectUtil.kt
+++ b/app/src/main/java/me/teble/xposed/autodaily/hook/proxy/activity/ResInjectUtil.kt
@@ -1,4 +1,5 @@
 @file:JvmName("ResInjectUtil")
+
 package me.teble.xposed.autodaily.hook.proxy.activity
 
 import android.content.res.Resources
@@ -9,11 +10,13 @@ import me.teble.xposed.autodaily.utils.LogUtil
 import me.teble.xposed.autodaily.utils.invoke
 
 fun injectRes(res: Resources = hostContext.resources) {
-    try {
-        res.getString(R.string.res_inject_success)
-        return
-    } catch (ignored: Resources.NotFoundException) {
-    }
+    // FIXME: 去除资源注入成功检测，每次重复注入资源，可以修复一些内置 Hook 框架注入虽然成功但是依然找不到资源 ID 的问题
+    //        复现：梦境框架、应用转生、LSPatch，QQ 版本 8.3.9、8.4.1
+    //    try {
+    //        res.getString(R.string.res_inject_success)
+    //        return
+    //    } catch (ignored: Resources.NotFoundException) {
+    //    }
     LogUtil.log("Module path = $modulePath")
     //-----资源注入部分-----
     val assets = res.assets


### PR DESCRIPTION
经过我的测试在一些内置 Hook 框架中，判断资源成功注入但是依然找不到资源 ID 导致注入失败，经过测试去除资源注入的判断代码，每次重复注入就能成功，而且这样做并未发现其它可能存在的问题，能够正常工作。