### PR TITLE
Fixed # 部分用户无法点击20次点赞，在20次点赞失败后，尝试改为点赞10次。如果再次失败，再判定为最终失败。

### DIFF
--- a/app/src/main/java/me/teble/xposed/autodaily/task/request/impl/FuncTaskReqUtil.kt
+++ b/app/src/main/java/me/teble/xposed/autodaily/task/request/impl/FuncTaskReqUtil.kt
@@ -52,8 +52,6 @@ object FuncTaskReqUtil : ITaskReqUtil {
                         Thread.sleep(1000)
                         if (favoriteManager.syncFavorite(uin, min(cnt.toInt(), 20))) {
                             favoriteCnt++
-                        }else if (favoriteManager.syncFavorite(uin, min(cnt.toInt(), 10))){
-                            favoriteCnt++
                         }
                     }
                 }
@@ -62,11 +60,18 @@ object FuncTaskReqUtil : ITaskReqUtil {
             url.startsWith("xa://FavoriteManager/favorite") -> {
                 val uin = paramMap["uin"]!!.toLong()
                 manager = favoriteManager
-                if (!favoriteManager.syncFavorite(uin, 20)) {
-                    if (!favoriteManager.syncFavorite(uin, 10)) {
-                        message = "执行失败"
-                        resultCode = -1
+                var ticket = 20 //最多点20次
+                while (ticket > 0){
+                    if (!favoriteManager.syncFavorite(uin, 1)) {
+                        break
                     }
+                    Thread.sleep(500)
+                    ticket--
+                }
+                //一次点赞都没成功，判定为点赞失败
+                if (ticket > 20-1){
+                    message = "执行失败"
+                    resultCode = -1
                 }
             }
             url.startsWith("xa://SendMessageManager/sendMessage/friend") -> {

--- a/app/src/main/java/me/teble/xposed/autodaily/task/request/impl/FuncTaskReqUtil.kt
+++ b/app/src/main/java/me/teble/xposed/autodaily/task/request/impl/FuncTaskReqUtil.kt
@@ -52,6 +52,8 @@ object FuncTaskReqUtil : ITaskReqUtil {
                         Thread.sleep(1000)
                         if (favoriteManager.syncFavorite(uin, min(cnt.toInt(), 20))) {
                             favoriteCnt++
+                        }else if (favoriteManager.syncFavorite(uin, min(cnt.toInt(), 10))){
+                            favoriteCnt++
                         }
                     }
                 }
@@ -61,8 +63,10 @@ object FuncTaskReqUtil : ITaskReqUtil {
                 val uin = paramMap["uin"]!!.toLong()
                 manager = favoriteManager
                 if (!favoriteManager.syncFavorite(uin, 20)) {
-                    message = "执行失败"
-                    resultCode = -1
+                    if (!favoriteManager.syncFavorite(uin, 10)) {
+                        message = "执行失败"
+                        resultCode = -1
+                    }
                 }
             }
             url.startsWith("xa://SendMessageManager/sendMessage/friend") -> {


### PR DESCRIPTION
经测试，一定程度上可以避免点赞和回赞失败。
很奇怪，按[这里的代码](https://github.com/LuckyPray/XAutoDaily/blob/b366d2e229097d1f42badadb4fba94ab636616cf/app/src/main/java/me/teble/xposed/autodaily/hook/function/impl/FavoriteManager.kt#L92)，应该是可以无视20次限制的，但是，实际上，依然会报点赞超时，实测，点赞超时的原因是只能点10次。
已测试，点赞10次是可以正常得到点赞成功的响应的。